### PR TITLE
Add Javadoc to test classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ test {
 }
 
 application {
-    mainClass.set("momo.Launcher")
+    mainClass.set("momo.gui.Launcher")
 }
 
 shadowJar {

--- a/src/main/java/momo/Momo.java
+++ b/src/main/java/momo/Momo.java
@@ -22,6 +22,7 @@ public class Momo {
     /** Handles all user interactions and displays messages. */
     private final Ui ui;
 
+    /** Stores the type of the last executed command as a string. */
     private String commandType;
 
     /**
@@ -32,14 +33,7 @@ public class Momo {
         storage = new Storage();
         tasks = new TaskList();
         ui = new Ui();
-        ui.getInitializingMessage();
-        try {
-            storage.load(tasks);
-        } catch (MomoException e) {
-            ui.getLoadingErrorMessage();
-        } finally {
-            ui.getInitializedMessage();
-        }
+        storage.load(tasks);
     }
 
     /**
@@ -69,7 +63,15 @@ public class Momo {
     }
 
     /**
-     * Generates a response for the user's chat message.
+     * Processes user input and generates a response.
+     *
+     * <p>This method parses the input into a command, executes it, updates the
+     * {@code commandType} field for GUI styling, and returns the response string.
+     * If a {@link MomoException} occurs during parsing or execution, it returns
+     * the error message and sets {@code commandType} to "Error".</p>
+     *
+     * @param input The raw user input string.
+     * @return A string containing the response to the user input, or an error message if an exception occurs.
      */
     public String getResponse(String input) {
         try {
@@ -84,6 +86,13 @@ public class Momo {
         }
     }
 
+    /**
+     * Returns the type of the last executed command as a string.
+     *
+     * <p>This is used by the GUI to determine the appropriate styling for the dialog box.</p>
+     *
+     * @return The last command type, or "Error" if the last execution failed.
+     */
     public String getCommandType() {
         return commandType;
     }

--- a/src/main/java/momo/command/AddDeadlineCommand.java
+++ b/src/main/java/momo/command/AddDeadlineCommand.java
@@ -35,7 +35,7 @@ public class AddDeadlineCommand implements Command {
      * @param tasks the task list to which the deadline is added.
      * @param ui the user interface used to generate messages.
      * @param storage the storage handler that saves the updated task list.
-     * @return the confirmation message after successfully adding the deadline           
+     * @return the confirmation message after successfully adding the deadline
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {

--- a/src/main/java/momo/command/UnmarkCommand.java
+++ b/src/main/java/momo/command/UnmarkCommand.java
@@ -23,7 +23,7 @@ public class UnmarkCommand implements Command {
     /**
      * Marks the task at the specified index in the task list as not done.
      * Also saves the updated task list to storage and
-     * displays a confirmation message to the user.
+     * returns a confirmation message to the user.
      *
      * @param tasks the task list containing the task to unmark.
      * @param ui the user interface used to generate messages (not used in this command).

--- a/src/main/java/momo/gui/DialogBox.java
+++ b/src/main/java/momo/gui/DialogBox.java
@@ -1,4 +1,4 @@
-package momo;
+package momo.gui;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -15,8 +15,12 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 
 /**
- * Represents a dialog box consisting of an ImageView to represent the speaker's face
- * and a label containing text from the speaker.
+ * Represents a dialog box containing a text label and an image.
+ *
+ * <p>The dialog box is used to display both user input and Momo's responses.
+ * User dialogs are aligned with the image on the right, while Momo's dialogs
+ * are flipped with the image on the left and styled according to the type of
+ * command executed.</p>
  */
 public class DialogBox extends HBox {
     @FXML
@@ -49,6 +53,11 @@ public class DialogBox extends HBox {
         dialog.getStyleClass().add("reply-label");
     }
 
+    /**
+     * Applies a CSS style to the dialog label based on the command type.
+     *
+     * @param commandType Type of command that triggered the response.
+     */
     private void changeDialogStyle(String commandType) {
         switch(commandType) {
         case "AddDeadlineCommand":
@@ -72,14 +81,36 @@ public class DialogBox extends HBox {
             dialog.getStyleClass().add("error-label");
             break;
         default:
-            // Do nothing
+            // No style applied for unrecognized command types
         }
     }
 
+    /**
+     * Creates a dialog box representing user input.
+     *
+     * <p>The dialog displays the text with the image on the right side and
+     * no additional styling applied.</p>
+     *
+     * @param text Text entered by the user.
+     * @param img  User's profile image.
+     * @return A dialog box containing the user's dialog.
+     */
     public static DialogBox getUserDialog(String text, Image img) {
         return new DialogBox(text, img);
     }
 
+    /**
+     * Creates a dialog box representing Momo's response.
+     *
+     * <p>The dialog is flipped horizontally with the image on the left side
+     * and styled according to the type of command executed. This distinguishes
+     * Momo's dialogs from the user's.</p>
+     *
+     * @param text Response text from Momo.
+     * @param img Momo's profile image.
+     * @param commandType Type of command that triggered the response.
+     * @return A dialog box containing Momo's styled dialog.
+     */
     public static DialogBox getMomoDialog(String text, Image img, String commandType) {
         var db = new DialogBox(text, img);
         db.flip();

--- a/src/main/java/momo/gui/Launcher.java
+++ b/src/main/java/momo/gui/Launcher.java
@@ -1,4 +1,4 @@
-package momo;
+package momo.gui;
 
 import javafx.application.Application;
 

--- a/src/main/java/momo/gui/Main.java
+++ b/src/main/java/momo/gui/Main.java
@@ -1,4 +1,4 @@
-package momo;
+package momo.gui;
 
 import java.io.IOException;
 
@@ -7,6 +7,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
+import momo.Momo;
 
 /**
  * A GUI for Momo using FXML.

--- a/src/main/java/momo/gui/MainWindow.java
+++ b/src/main/java/momo/gui/MainWindow.java
@@ -1,4 +1,4 @@
-package momo;
+package momo.gui;
 
 import javafx.application.Platform;
 import javafx.fxml.FXML;
@@ -8,6 +8,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
+import momo.Momo;
 
 /**
  * Controller for the main GUI.
@@ -27,6 +28,11 @@ public class MainWindow extends AnchorPane {
     private Image userImage = new Image(this.getClass().getResourceAsStream("/images/DaUser.png"));
     private Image momoImage = new Image(this.getClass().getResourceAsStream("/images/DaMomo.png"));
 
+    /**
+     * Initializes the controller.
+     *
+     * <p>Binds the scroll pane to the dialog container height and shows Momo's welcome message.</p>
+     */
     @FXML
     public void initialize() {
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());

--- a/src/main/java/momo/storage/Storage.java
+++ b/src/main/java/momo/storage/Storage.java
@@ -37,12 +37,11 @@ public class Storage {
 
     /**
      * Loads tasks from the file in the local file system into the given task list.
-     * Clears the task list and throws {@link MomoException} if the saved data is invalid.
-     *
+     * If reading the file or parsing the saved data fails, the task list is cleared
+     * to prevent partial or corrupted data.
      * @param tasks the task list to load tasks into.
-     * @throws MomoException if the saved data is malformed or cannot be read.
      */
-    public void load(TaskList tasks) throws MomoException {
+    public void load(TaskList tasks) {
         Path filePath = Paths.get(DIRECTORY).resolve(FILE_NAME);
         if (!Files.exists(filePath)) {
             return;
@@ -53,11 +52,8 @@ public class Storage {
                 Task task = Parser.parseToTask(line);
                 tasks.addTask(task);
             }
-        } catch (IOException e) {
-            throw new MomoException("Unable to read saved data in hard disk");
-        } catch (MomoException e) {
+        } catch (IOException | MomoException e) {
             tasks.clear();
-            throw e;
         }
     }
 }

--- a/src/main/java/momo/ui/Ui.java
+++ b/src/main/java/momo/ui/Ui.java
@@ -16,12 +16,6 @@ public class Ui {
             + "| |  | | (_) | | | | | | (_) |\n"
             + "|_|  |_|\\___/|_| |_| |_|\\___/\n";
 
-    /** Message displayed when Momo is initializing. */
-    private static final String MESSAGE_INITIALIZING = "Initializing Momo...";
-
-    /** Message displayed after Momo has been initialized. */
-    private static final String MESSAGE_INITIALIZED = "Momo initialized!";
-
     /** Welcome message displayed at startup. */
     private static final String MESSAGE_WELCOME = "Hello I'm\n" + LOGO + "\n" + "What can I do for you?";
 
@@ -54,42 +48,6 @@ public class Ui {
      */
     public String getWelcomeMessage() {
         return MESSAGE_WELCOME;
-    }
-
-    /**
-     * Returns a message indicating that the application is initializing.
-     *
-     * @return the initializing message as a string.
-     */
-    public String getInitializingMessage() {
-        return MESSAGE_INITIALIZING;
-    }
-
-    /**
-     * Returns a message indicating that the application has been initialized.
-     *
-     * @return the initialized message as a string.
-     */
-    public String getInitializedMessage() {
-        return MESSAGE_INITIALIZED;
-    }
-
-    /**
-     * Returns a message indicating that saved tasks are being retrieved from disk.
-     *
-     * @return the retrieving data message as a string.
-     */
-    public String getRetrievingDataMessage() {
-        return "Retrieving saved data from hard disk if any...";
-    }
-
-    /**
-     * Returns a message indicating that loading saved data from disk has failed.
-     *
-     * @return the loading error message as a string.
-     */
-    public String getLoadingErrorMessage() {
-        return "Error loading data from hard disk...\nDefaulting to fresh state...";
     }
 
     /**

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="400.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="momo.MainWindow">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="400.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="momo.gui.MainWindow">
     <children>
         <TextField fx:id="userInput" layoutY="558.0" onAction="#handleUserInput" prefHeight="41.0" prefWidth="324.0" AnchorPane.bottomAnchor="1.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="76.0" />
         <Button fx:id="sendButton" layoutX="324.0" layoutY="558.0" mnemonicParsing="false" onAction="#handleUserInput" prefHeight="41.0" prefWidth="76.0" text="Send" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="0.0" />

--- a/src/test/java/momo/parser/ParserTest.java
+++ b/src/test/java/momo/parser/ParserTest.java
@@ -26,55 +26,91 @@ import momo.task.Event;
 import momo.task.Task;
 import momo.task.Todo;
 
+/**
+ * Unit tests for the {@link Parser} class.
+ *
+ * <p>This class verifies that commands and tasks are correctly parsed from
+ * user input strings or saved task data. It tests both valid inputs
+ * (ensuring correct objects are returned) and invalid inputs
+ * (ensuring {@link MomoException} is thrown with the correct message).</p>
+ */
 public class ParserTest {
+
+    /**
+     * Tests that the "bye" command is correctly parsed into an {@link ExitCommand}.
+     */
     @Test
     public void parseToCommand_bye_success() throws MomoException {
         Command command = Parser.parseToCommand("bye");
         assertInstanceOf(ExitCommand.class, command);
     }
 
+    /**
+     * Tests that the "list" command is correctly parsed into a {@link ListCommand}.
+     */
     @Test
     public void parseToCommand_list_success() throws MomoException {
         Command command = Parser.parseToCommand("list");
         assertInstanceOf(ListCommand.class, command);
     }
 
+    /**
+     * Tests that a valid "todo" command is correctly parsed into {@link AddTodoCommand}.
+     */
     @Test
     public void parseToCommand_todo_success() throws MomoException {
         Command command = Parser.parseToCommand("todo read book");
         assertInstanceOf(AddTodoCommand.class, command);
     }
 
+    /**
+     * Tests that a "todo" command with missing description throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_todoMissingDescription_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("todo"));
         assertTrue(e.getMessage().contains("The description of the todo is empty"));
     }
 
+    /**
+     * Tests that a valid "find" command is correctly parsed into {@link FindCommand}.
+     */
     @Test
     public void parseToCommand_find_success() throws MomoException {
         Command command = Parser.parseToCommand("find book");
         assertInstanceOf(FindCommand.class, command);
     }
 
+    /**
+     * Tests that a "find" command with missing keyword throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_findMissingKeyword_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("find"));
         assertTrue(e.getMessage().contains("The keyword to find is missing"));
     }
 
+    /**
+     * Tests that a valid "deadline" command is correctly parsed into {@link AddDeadlineCommand}.
+     */
     @Test
     public void parseToCommand_deadline_success() throws MomoException {
         Command command = Parser.parseToCommand("deadline return book /by 2025-12-02 1800");
         assertInstanceOf(AddDeadlineCommand.class, command);
     }
 
+    /**
+     * Tests that a "deadline" command with missing description throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_deadlineMissingDescription_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("deadline"));
         assertTrue(e.getMessage().contains("The description of the deadline is empty"));
     }
 
+    /**
+     * Tests that a "deadline" command missing the "/by" part throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_deadlineMissingBy_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("deadline return book"));
@@ -82,6 +118,9 @@ public class ParserTest {
     }
 
     //CHECKSTYLE.OFF: SeparatorWrap
+    /**
+     * Tests that a "deadline" command with invalid date-time format throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_deadlineInvalidDateTimeFormat_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class,
@@ -90,6 +129,9 @@ public class ParserTest {
     }
     //CHECKSTYLE.ON: SeparatorWrap
 
+    /**
+     * Tests that a valid "event" command is correctly parsed into {@link AddEventCommand}.
+     */
     @Test
     public void parseToCommand_event_success() throws MomoException {
         String trimmedInput = "event project meeting /from 2025-12-02 1200 /to 2025-12-02 1400";
@@ -97,12 +139,18 @@ public class ParserTest {
         assertInstanceOf(AddEventCommand.class, command);
     }
 
+    /**
+     * Tests that an "event" command with missing description throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_eventMissingDescription_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("event"));
         assertTrue(e.getMessage().contains("The description of the event is empty"));
     }
 
+    /**
+     * Tests that an "event" command missing the "/from" part throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_eventMissingFrom_exceptionThrown() {
         String trimmedInput = "event project meeting /to 2025-12-02 1400";
@@ -110,6 +158,9 @@ public class ParserTest {
         assertTrue(e.getMessage().contains("The event is missing \"/from\""));
     }
 
+    /**
+     * Tests that an "event" command missing the "/to" part throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_eventMissingTo_exceptionThrown() {
         String trimmedInput = "event project meeting /from 2025-12-02 1200";
@@ -117,6 +168,9 @@ public class ParserTest {
         assertTrue(e.getMessage().contains("The event is missing \"/to\""));
     }
 
+    /**
+     * Tests that an "event" command with invalid date-time format throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_eventInvalidDateTimeFormat_exceptionThrown() {
         String trimmedInput = "event project meeting /from Monday 12pm /to 2pm";
@@ -124,6 +178,9 @@ public class ParserTest {
         assertTrue(e.getMessage().contains("The format of date and time entered is invalid"));
     }
 
+    /**
+     * Tests that a valid "delete" command is correctly parsed into {@link DeleteCommand}.
+     */
     @Test
     public void parseToCommand_delete_success() throws MomoException {
         String trimmedInput = "delete 2";
@@ -131,18 +188,27 @@ public class ParserTest {
         assertInstanceOf(DeleteCommand.class, command);
     }
 
+    /**
+     * Tests that a "delete" command with missing task number throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_deleteMissingTaskNumber_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("delete"));
         assertTrue(e.getMessage().contains("The task number to delete is not provided"));
     }
 
+    /**
+     * Tests that a "delete" command with a non-integer task number throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_deleteTaskNumberNotInteger_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("delete two"));
         assertTrue(e.getMessage().contains("The task number provided is not an integer"));
     }
 
+    /**
+     * Tests that a valid "mark" command is correctly parsed into {@link MarkCommand}.
+     */
     @Test
     public void parseToCommand_mark_success() throws MomoException {
         String trimmedInput = "mark 2";
@@ -150,18 +216,27 @@ public class ParserTest {
         assertInstanceOf(MarkCommand.class, command);
     }
 
+    /**
+     * Tests that a "mark" command with missing task number throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_markMissingTaskNumber_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("mark"));
         assertTrue(e.getMessage().contains("The task number to mark is not provided"));
     }
 
+    /**
+     * Tests that a "mark" command with a non-integer task number throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_markTaskNumberNotInteger_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("mark two"));
         assertTrue(e.getMessage().contains("The task number provided is not an integer"));
     }
 
+    /**
+     * Tests that a valid "unmark" command is correctly parsed into {@link UnmarkCommand}.
+     */
     @Test
     public void parseToCommand_unmark_success() throws MomoException {
         String trimmedInput = "unmark 2";
@@ -169,30 +244,45 @@ public class ParserTest {
         assertInstanceOf(UnmarkCommand.class, command);
     }
 
+    /**
+     * Tests that an "unmark" command with missing task number throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_unmarkMissingTaskNumber_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("unmark"));
         assertTrue(e.getMessage().contains("The task number to unmark is not provided"));
     }
 
+    /**
+     * Tests that an "unmark" command with a non-integer task number throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_unmarkTaskNumberNotInteger_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("unmark two"));
         assertTrue(e.getMessage().contains("The task number provided is not an integer"));
     }
 
+    /**
+     * Tests that an invalid command string throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_invalidCommand_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand("blah"));
         assertTrue(e.getMessage().contains("is not a valid command"));
     }
 
+    /**
+     * Tests that an empty input string throws a {@link MomoException}.
+     */
     @Test
     public void parseToCommand_emptyInput_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToCommand(""));
         assertTrue(e.getMessage().contains("is not a valid command"));
     }
 
+    /**
+     * Tests that a saved "todo" task string is correctly parsed into {@link Todo}.
+     */
     @Test
     public void parseToTask_todo_success() throws MomoException {
         Task task = Parser.parseToTask("T | 0 | read book");
@@ -202,6 +292,9 @@ public class ParserTest {
     }
 
     //CHECKSTYLE.OFF: SeparatorWrap
+    /**
+     * Tests that a saved "deadline" task string is correctly parsed into {@link Deadline}.
+     */
     @Test
     public void parseToTask_deadline_success() throws MomoException {
         Task task = Parser.parseToTask("D | 1 | return book | 2025-12-02 1800");
@@ -214,6 +307,9 @@ public class ParserTest {
     //CHECKSTYLE.ON: SeparatorWrap
 
     //CHECKSTYLE.OFF: SeparatorWrap
+    /**
+     * Tests that a saved "event" task string is correctly parsed into {@link Event}.
+     */
     @Test
     public void parseToTask_event_success() throws MomoException {
         Task task = Parser.parseToTask("E | 0 | meeting | 2025-12-02 1200 | 2025-12-02 1400");
@@ -227,12 +323,18 @@ public class ParserTest {
     }
     //CHECKSTYLE.ON: SeparatorWrap
 
+    /**
+     * Tests that a task string with an invalid type throws a {@link MomoException}.
+     */
     @Test
     void parseToTask_invalidTaskType_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToTask("L | 0 | meeting"));
         assertTrue(e.getMessage().contains("Invalid task type found"));
     }
 
+    /**
+     * Tests that a task string missing required data throws a {@link MomoException}.
+     */
     @Test
     void parseToTask_missingData_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToTask("E | 0 | meeting"));
@@ -240,6 +342,9 @@ public class ParserTest {
     }
 
     //CHECKSTYLE.OFF: SeparatorWrap
+    /**
+     * Tests that a task string with invalid date-time format throws a {@link MomoException}.
+     */
     @Test
     void parseToTask_invalidDateTimeFormat_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class,
@@ -248,6 +353,9 @@ public class ParserTest {
     }
     //CHECKSTYLE.ON: SeparatorWrap
 
+    /**
+     * Tests that an empty task string throws a {@link MomoException}.
+     */
     @Test
     public void parseToTask_emptyInput_exceptionThrown() {
         MomoException e = assertThrows(MomoException.class, () -> Parser.parseToTask(""));

--- a/src/test/java/momo/task/DeadlineTest.java
+++ b/src/test/java/momo/task/DeadlineTest.java
@@ -6,7 +6,18 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for the {@link Deadline} class.
+ *
+ * <p>These tests verify that the string representation and save format of
+ * deadlines are correctly generated for both completed and uncompleted tasks.</p>
+ */
 public class DeadlineTest {
+
+    /**
+     * Tests the {@link Deadline#toString()} method when the deadline is marked as done.
+     * Verifies that the output includes the "[X]" done marker and correctly formatted date/time.
+     */
     @Test
     public void toString_done() {
         String description = "return book";
@@ -16,6 +27,10 @@ public class DeadlineTest {
         assertEquals("[D][X] return book (by: Dec 2 2025, 12:00pm)", deadline.toString());
     }
 
+    /**
+     * Tests the {@link Deadline#toString()} method when the deadline is not done.
+     * Verifies that the output includes the "[ ]" marker and correctly formatted date/time.
+     */
     @Test
     public void toString_notDone() {
         String description = "return book";
@@ -25,6 +40,10 @@ public class DeadlineTest {
         assertEquals("[D][ ] return book (by: Dec 2 2025, 12:00pm)", deadline.toString());
     }
 
+    /**
+     * Tests the {@link Deadline#convertToSaveFormat()} method for a completed deadline.
+     * Ensures the returned string correctly encodes the task type, done status, description, and datetime.
+     */
     @Test
     public void convertToSaveFormat_done() {
         String description = "return book";
@@ -34,6 +53,10 @@ public class DeadlineTest {
         assertEquals("D | 1 | return book | 2025-12-02 1200", deadline.convertToSaveFormat());
     }
 
+    /**
+     * Tests the {@link Deadline#convertToSaveFormat()} method for an uncompleted deadline.
+     * Ensures the returned string correctly encodes the task type, not-done status, description, and datetime.
+     */
     @Test
     public void convertToSaveFormat_notDone() {
         String description = "return book";

--- a/src/test/java/momo/task/EventTest.java
+++ b/src/test/java/momo/task/EventTest.java
@@ -6,8 +6,18 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
-
+/**
+ * Unit tests for the {@link Event} class.
+ *
+ * <p>These tests verify that the string representation and save format of
+ * events are correctly generated for both completed and uncompleted tasks.</p>
+ */
 public class EventTest {
+
+    /**
+     * Tests the {@link Event#toString()} method when the event is marked as done.
+     * Verifies that the output includes the "[X]" done marker and correctly formatted start and end date/time.
+     */
     @Test
     public void toString_done() {
         String description = "project meeting";
@@ -19,6 +29,10 @@ public class EventTest {
                 event.toString());
     }
 
+    /**
+     * Tests the {@link Event#toString()} method when the event is not done.
+     * Verifies that the output includes the "[ ]" marker and correctly formatted start and end date/time.
+     */
     @Test
     public void toString_notDone() {
         String description = "project meeting";
@@ -30,6 +44,10 @@ public class EventTest {
                 event.toString());
     }
 
+    /**
+     * Tests the {@link Event#convertToSaveFormat()} method for a completed event.
+     * Ensures the returned string correctly encodes the task type, done status, description, and date/time range.
+     */
     @Test
     public void convertToSaveFormat_done() {
         String description = "project meeting";
@@ -41,6 +59,10 @@ public class EventTest {
                 event.convertToSaveFormat());
     }
 
+    /**
+     * Tests the {@link Event#convertToSaveFormat()} method for an uncompleted event.
+     * Ensures the returned string correctly encodes the task type, not-done status, description, and date/time range.
+     */
     @Test
     public void convertToSaveFormat_notDone() {
         String description = "project meeting";

--- a/src/test/java/momo/task/TaskListTest.java
+++ b/src/test/java/momo/task/TaskListTest.java
@@ -7,20 +7,35 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for the {@link TaskList} class.
+ *
+ * <p>These tests verify that tasks can be added, deleted, retrieved, marked/unmarked,
+ * converted to save format, and cleared correctly.</p>
+ */
 public class TaskListTest {
     private TaskList tasks;
 
+    /**
+     * Initializes a new {@link TaskList} before each test.
+     */
     @BeforeEach
     public void setUp() {
         tasks = new TaskList();
     }
 
+    /**
+     * Tests that adding a task increases the size of the task list.
+     */
     @Test
     public void addTask_increasesSize() {
         tasks.addTask(new Todo("read book", false));
         assertEquals(1, tasks.size());
     }
 
+    /**
+     * Tests that deleting a task returns the correct task and removes it from the list.
+     */
     @Test
     public void deleteTask_returnsAndRemovesCorrectTask() {
         Todo todo = new Todo("read book", false);
@@ -30,6 +45,9 @@ public class TaskListTest {
         assertEquals(0, tasks.size());
     }
 
+    /**
+     * Tests that retrieving a task by index returns the correct task.
+     */
     @Test
     public void getTask_returnsCorrectTask() {
         Todo todoHomework = new Todo("do homework", false);
@@ -41,6 +59,9 @@ public class TaskListTest {
         assertEquals(todoCallJohn, tasks.getTask(1));
     }
 
+    /**
+     * Tests that marking and unmarking a task updates its completion state correctly.
+     */
     @Test
     public void markAndUnmarkTask_updatesState() {
         Todo todo = new Todo("exercise", false);
@@ -53,6 +74,10 @@ public class TaskListTest {
         assertFalse(tasks.getTask(0).isDone());
     }
 
+    /**
+     * Tests that {@link TaskList#convertToSaveFormat()} returns a string containing
+     * all tasks in the correct save format, joined by line separators.
+     */
     @Test
     public void convertToSaveFormat_returnsJoinedString() {
         tasks.addTask(new Todo("read manga", false));
@@ -61,6 +86,9 @@ public class TaskListTest {
         assertEquals(expected, tasks.convertToSaveFormat());
     }
 
+    /**
+     * Tests that clearing the task list removes all tasks and results in an empty list.
+     */
     @Test
     public void clear_removesAllTasks() {
         tasks.addTask(new Todo("pay Henry", false));

--- a/src/test/java/momo/task/TodoTest.java
+++ b/src/test/java/momo/task/TodoTest.java
@@ -4,7 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for the {@link Todo} class.
+ *
+ * <p>These tests verify that the {@code Todo} class correctly formats
+ * its string representation and save format for both completed and
+ * incomplete tasks.</p>
+ */
 public class TodoTest {
+
+    /**
+     * Tests the {@link Todo#toString()} method for a completed task.
+     * Verifies that the string representation includes the "[X]" mark.
+     */
     @Test
     public void toString_done() {
         String description = "read book";
@@ -13,6 +25,10 @@ public class TodoTest {
         assertEquals("[T][X] read book", todo.toString());
     }
 
+    /**
+     * Tests the {@link Todo#toString()} method for an incomplete task.
+     * Verifies that the string representation includes the "[ ]" mark.
+     */
     @Test
     public void toString_notDone() {
         String description = "read book";
@@ -21,6 +37,10 @@ public class TodoTest {
         assertEquals("[T][ ] read book", todo.toString());
     }
 
+    /**
+     * Tests the {@link Todo#convertToSaveFormat()} method for a completed task.
+     * Verifies that the returned string uses "1" to indicate completion.
+     */
     @Test
     public void convertToSaveFormat_done() {
         String description = "read book";
@@ -29,6 +49,10 @@ public class TodoTest {
         assertEquals("T | 1 | read book", todo.convertToSaveFormat());
     }
 
+    /**
+     * Tests the {@link Todo#convertToSaveFormat()} method for an incomplete task.
+     * Verifies that the returned string uses "0" to indicate the task is not done.
+     */
     @Test
     public void convertToSaveFormat_notDone() {
         String description = "read book";


### PR DESCRIPTION
Test classes for Todo, Deadline, Event, TaskList, and Parser contain multiple unit tests.

Lack of Javadoc makes it harder for developers to understand the purpose and behavior of each test method.

Let's add class-level and method-level Javadoc to describe the intent, input conditions, and expected outcomes of each test clearly.

This improves code readability and maintainability, allowing future developers to understand the tests without delving into implementation details.

Ensure clarity and conciseness; Javadoc follows standard conventions to maintain consistency across all test classes.