### PR TITLE
Add assertions to command classes

### DIFF
--- a/src/main/java/momo/command/AddDeadlineCommand.java
+++ b/src/main/java/momo/command/AddDeadlineCommand.java
@@ -23,6 +23,10 @@ public class AddDeadlineCommand implements Command {
      * @param by the due date and time of the deadline task.
      */
     public AddDeadlineCommand(String description, LocalDateTime by) {
+        assert description != null : "Description must not be null";
+        assert !description.trim().isEmpty() : "Description must not be empty";
+        assert by != null : "Deadline date/time must not be null";
+
         this.description = description;
         this.by = by;
     }
@@ -35,12 +39,19 @@ public class AddDeadlineCommand implements Command {
      * @param tasks the task list to which the deadline is added.
      * @param ui the user interface used to generate messages.
      * @param storage the storage handler that saves the updated task list.
-     * @return the confirmation message after successfully adding the deadline           
+     * @return the confirmation message after successfully adding the deadline
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         Task task = new Deadline(description, by);
         tasks.addTask(task);
+
+        assert tasks.size() > 0 : "Task list should contain at least one task after adding a deadline";
+
         storage.save(tasks);
         return ui.getAddTaskMessage(task, tasks);
     }

--- a/src/main/java/momo/command/AddEventCommand.java
+++ b/src/main/java/momo/command/AddEventCommand.java
@@ -25,6 +25,12 @@ public class AddEventCommand implements Command {
      * @param to the end date and time of the event.
      */
     public AddEventCommand(String description, LocalDateTime from, LocalDateTime to) {
+        assert description != null : "Description must not be null";
+        assert !description.trim().isEmpty() : "Description must not be empty";
+        assert from != null : "Start time must not be null";
+        assert to != null : "End time must not be null";
+        assert from.isBefore(to) : "Start time must be before end time";
+
         this.description = description;
         this.from = from;
         this.to = to;
@@ -42,8 +48,15 @@ public class AddEventCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         Task task = new Event(description, from, to);
         tasks.addTask(task);
+
+        assert tasks.size() > 0 : "Task list should not be empty after adding an event";
+
         storage.save(tasks);
         return ui.getAddTaskMessage(task, tasks);
     }

--- a/src/main/java/momo/command/AddTodoCommand.java
+++ b/src/main/java/momo/command/AddTodoCommand.java
@@ -19,6 +19,9 @@ public class AddTodoCommand implements Command {
      * @param description the description of the todo task.
      */
     public AddTodoCommand(String description) {
+        assert description != null : "Description must not be null";
+        assert !description.trim().isEmpty() : "Description must not be empty";
+
         this.description = description;
     }
 
@@ -34,8 +37,15 @@ public class AddTodoCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         Task task = new Todo(description);
         tasks.addTask(task);
+
+        assert tasks.size() > 0 : "Task list should not be empty after adding a todo";
+
         storage.save(tasks);
         return ui.getAddTaskMessage(task, tasks);
     }

--- a/src/main/java/momo/command/DeleteCommand.java
+++ b/src/main/java/momo/command/DeleteCommand.java
@@ -34,12 +34,19 @@ public class DeleteCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws MomoException {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         if (index < 0 || index >= tasks.size()) {
             String errorDetail = "The task number provided is invalid!";
             String errorFix = "Fix: Retry \"delete <task number>\" with a valid task number!";
             throw new MomoException(errorDetail + "\n" + errorFix);
         }
         Task deletedTask = tasks.deleteTask(index);
+
+        assert tasks.size() >= 0 : "Task list size should be non-negative after deletion";
+
         storage.save(tasks);
         return ui.getDeleteTaskMessage(deletedTask, tasks);
     }

--- a/src/main/java/momo/command/ExitCommand.java
+++ b/src/main/java/momo/command/ExitCommand.java
@@ -19,6 +19,10 @@ public class ExitCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         return ui.getByeMessage();
     }
 

--- a/src/main/java/momo/command/FindCommand.java
+++ b/src/main/java/momo/command/FindCommand.java
@@ -21,6 +21,9 @@ public class FindCommand implements Command {
      * @param keyword the keyword to find in task descriptions.
      */
     public FindCommand(String keyword) {
+        assert keyword != null : "Keyword must not be null";
+        assert !keyword.trim().isEmpty() : "Keyword must not be empty";
+
         this.keyword = keyword;
     }
 
@@ -35,6 +38,10 @@ public class FindCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         List<Task> foundTasks = tasks.stream()
                 .filter(task -> task.getDescription().contains(keyword))
                 .toList();

--- a/src/main/java/momo/command/ListCommand.java
+++ b/src/main/java/momo/command/ListCommand.java
@@ -23,6 +23,10 @@ public class ListCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         String listMessage = IntStream.range(0, tasks.size())
                 .mapToObj(x -> String.format("%d.%s", x + 1, tasks.getTask(x).toString()))
                 .collect(Collectors.joining("\n"));

--- a/src/main/java/momo/command/MarkCommand.java
+++ b/src/main/java/momo/command/MarkCommand.java
@@ -33,12 +33,19 @@ public class MarkCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws MomoException {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         if (index < 0 || index >= tasks.size()) {
             String errorDetail = "The task number provided is invalid!";
             String errorFix = "Fix: Retry \"mark <task number>\" with a valid task number!";
             throw new MomoException(errorDetail + "\n" + errorFix);
         }
         tasks.markTask(index);
+
+        assert tasks.getTask(index).isDone() : "Task should be marked as done after execution";
+
         storage.save(tasks);
         return "Nice! I've marked this task as done:\n  " + tasks.getTask(index).toString();
     }

--- a/src/main/java/momo/command/UnmarkCommand.java
+++ b/src/main/java/momo/command/UnmarkCommand.java
@@ -33,12 +33,19 @@ public class UnmarkCommand implements Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws MomoException {
+        assert tasks != null : "TaskList must not be null";
+        assert ui != null : "Ui must not be null";
+        assert storage != null : "Storage must not be null";
+
         if (index < 0 || index >= tasks.size()) {
             String errorDetail = "The task number provided is invalid!";
             String errorFix = "Fix: Retry \"unmark <task number>\" with a valid task number!";
             throw new MomoException(errorDetail + "\n" + errorFix);
         }
         tasks.unmarkTask(index);
+
+        assert !tasks.getTask(index).isDone() : "Task should be marked as not done after execution";
+
         storage.save(tasks);
         return "OK, I've marked this task as not done yet:\n  " + tasks.getTask(index).toString();
     }


### PR DESCRIPTION
Command classes do not use Java assertions.

Without explicit assertions, it is harder to reason about the correctness of commands.

Let's add assertions in constructors and in execute() methods of command classes.